### PR TITLE
Update for TB115

### DIFF
--- a/api/authRequest.js
+++ b/api/authRequest.js
@@ -2,7 +2,6 @@ Cu.importGlobalProperties(["btoa"]);
 
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
 var { ExtensionUtils } = ChromeUtils.import("resource://gre/modules/ExtensionUtils.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { LoginManagerPrompter } = ChromeUtils.import("resource://gre/modules/LoginManagerPrompter.jsm");
 
 var bundle = Services.strings.createBundle("chrome://global/locale/commonDialogs.properties");
@@ -85,9 +84,13 @@ var authRequest = class extends ExtensionCommon.ExtensionAPI {
           let usernameInput = {};
           let passwordInput = {};
           let prompter = Services.ww.getNewAuthPrompter(Services.ww.activeWindow);
-          if (!prompter.promptUsernameAndPassword(
+          let passwordPrompter = prompter.asyncPromptUsernameAndPassword
+            ? prompter.asyncPromptUsernameAndPassword
+            : prompter.promptUsernameAndPassword
+
+          if (!(await passwordPrompter(
             title, text, prePath, Ci.nsIAuthPrompt.SAVE_PASSWORD_PERMANENTLY, usernameInput, passwordInput
-          )) {
+          ))) {
             throw new ExtensionUtils.ExtensionError("Authorization prompt cancelled");
           }
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,8 +5,8 @@
   "applications": {
     "gecko": {
       "id": "dav-cloudfile@darktrojan.net",
-      "strict_min_version": "91.0",
-      "strict_max_version": "102.*"
+      "strict_min_version": "102.0",
+      "strict_max_version": "115.*"
     }
   },
   "background": {


### PR DESCRIPTION
Since TB102, the Service module is globally available for extensions and does not need to be loaded anymore.

The `promptUsernameAndPassword()` function still exists in TB115, but throws an error that it does not exist. Switching to `asyncPromptUsernameAndPassword()` (which is TB115 only).

I added a fallback for TB102, because there is a strange bug on ATN, that add-ons that have their latest submission being for TB115 only, not showing up in TB102 anymore (or marked as incompatible). So I tried to create a version which runs in both.

Edit: Could be that `Services` is defined global for much longer than TB102:
https://firefox-source-docs.mozilla.org/toolkit/components/extensions/webextensions/basics.html#globals-available-in-the-api-scripts-global